### PR TITLE
Limit default keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ text and generating selectors from any webpage.
 The popup provides buttons to activate each tool. Data from the page is copied to your
 clipboard and displayed in a short notification.
 
+## Keyboard Shortcuts
+Pickachu defines a few default shortcuts using the Chrome `commands` API. Due to a
+Chrome limitation only **four** commands can be registered. The following shortcuts
+are included by default and can be customised from the extension settings page:
+
+| Action | Shortcut |
+| ------ | -------- |
+| Activate color picker | `Alt+Shift+C` |
+| Activate element picker | `Alt+Shift+E` |
+| Activate link picker | `Alt+Shift+L` |
+| Activate selector generator | `Alt+Shift+S` |
+
+Other tools remain accessible from the popup menu.
+
 ## Repository Structure
 ```
 extension/

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -69,24 +69,6 @@
       },
       "description": "Activate link picker"
     },
-    "font-picker": {
-      "suggested_key": {
-        "default": "Alt+Shift+F"
-      },
-      "description": "Activate font picker"
-    },
-    "image-picker": {
-      "suggested_key": {
-        "default": "Alt+Shift+I"
-      },
-      "description": "Activate image picker"
-    },
-    "text-picker": {
-      "suggested_key": {
-        "default": "Alt+Shift+T"
-      },
-      "description": "Activate text picker"
-    },
     "selector-generator": {
       "suggested_key": {
         "default": "Alt+Shift+S"


### PR DESCRIPTION
## Summary
- trim `manifest.json` to four commands
- document default keyboard shortcuts in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6866efe92fd88331a990814fc2a0a9a2