### PR TITLE
Improve Pickachu modal UX

### DIFF
--- a/extension/content/content.css
+++ b/extension/content/content.css
@@ -1,3 +1,22 @@
+:root {
+  --pickachu-bg: #fff;
+  --pickachu-text: #333;
+  --pickachu-overlay: rgba(0,0,0,0.5);
+  --pickachu-button-bg: #f0f0f0;
+  --pickachu-button-border: #ccc;
+  --pickachu-hover: #e0e0e0;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --pickachu-bg: #2b2b2b;
+    --pickachu-text: #f5f5f5;
+    --pickachu-overlay: rgba(0,0,0,0.7);
+    --pickachu-button-bg: #3c3c3c;
+    --pickachu-button-border: #555;
+    --pickachu-hover: #555;
+  }
+}
+
 #pickachu-highlight-overlay {
   position: absolute;
   background-color: rgba(68,138,255,0.3);
@@ -23,8 +42,8 @@
 }
 #pickachu-tooltip {
   position: absolute;
-  background: #333;
-  color: #fff;
+  background: var(--pickachu-button-bg, #333);
+  color: var(--pickachu-text, #fff);
   font-family: monospace;
   font-size: 12px;
   padding: 4px 6px;
@@ -36,20 +55,29 @@
 #pickachu-modal-overlay {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.5);
+  background: var(--pickachu-overlay, rgba(0,0,0,0.5));
   z-index: 2147483647;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 #pickachu-modal-content {
-  background: #fff;
+  background: var(--pickachu-bg, #fff);
   padding: 20px;
   border-radius: 8px;
   max-width: 80%;
   max-height: 80vh;
   overflow-y: auto;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  resize: both;
+  color: var(--pickachu-text, #333);
+}
+#pickachu-modal-content pre {
+  white-space: pre-wrap;
 }
 #pickachu-modal-buttons {
   margin-top: 15px;
@@ -58,10 +86,15 @@
 #pickachu-modal-buttons button {
   margin-left: 10px;
   padding: 6px 12px;
-  border: 1px solid #ccc;
-  background: #f0f0f0;
+  border: 1px solid var(--pickachu-button-border, #ccc);
+  background: var(--pickachu-button-bg, #f0f0f0);
   border-radius: 4px;
   cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+#pickachu-modal-buttons button:hover {
+  background: var(--pickachu-hover, #e0e0e0);
+  transform: translateY(-2px);
 }
 #pickachu-modal-buttons button.copy {
   background: #448aff;
@@ -89,4 +122,17 @@
 
 #pickachu-history .history-item button {
   margin-right: 5px;
+}
+
+#pickachu-toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  z-index: 2147483647;
+  font-size: 12px;
 }

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -3,42 +3,42 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>__MSG_extensionName__</title>
+  <title data-i18n="extensionName">Pickachu</title>
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
   <header class="header">
-    <h1>__MSG_extensionName__ ⚡️</h1>
-    <p>__MSG_popupSubtitle__</p>
+    <h1 data-i18n="extensionName">Pickachu</h1>
+    <p data-i18n="popupSubtitle">Quick web picker tools</p>
   </header>
   <div class="grid">
-    <button id="color-picker" title="__MSG_colorPicker__">
+    <button id="color-picker" data-i18n-title="colorPicker">
       <span class="icon">🎨</span>
-      <span class="label">__MSG_color__</span>
+      <span class="label" data-i18n="color">Color</span>
     </button>
-    <button id="element-picker" title="__MSG_elementPicker__">
+    <button id="element-picker" data-i18n-title="elementPicker">
       <span class="icon">🧱</span>
-      <span class="label">__MSG_element__</span>
+      <span class="label" data-i18n="element">Element</span>
     </button>
-    <button id="link-picker" title="__MSG_linkPicker__">
+    <button id="link-picker" data-i18n-title="linkPicker">
       <span class="icon">🔗</span>
-      <span class="label">__MSG_link__</span>
+      <span class="label" data-i18n="link">Link</span>
     </button>
-    <button id="font-picker" title="__MSG_fontPicker__">
+    <button id="font-picker" data-i18n-title="fontPicker">
       <span class="icon">🔤</span>
-      <span class="label">__MSG_font__</span>
+      <span class="label" data-i18n="font">Font</span>
     </button>
-    <button id="image-picker" title="__MSG_imagePicker__">
+    <button id="image-picker" data-i18n-title="imagePicker">
       <span class="icon">🖼️</span>
-      <span class="label">__MSG_image__</span>
+      <span class="label" data-i18n="image">Image</span>
     </button>
-    <button id="text-picker" title="__MSG_textPicker__">
+    <button id="text-picker" data-i18n-title="textPicker">
       <span class="icon">🧾</span>
-      <span class="label">__MSG_text__</span>
+      <span class="label" data-i18n="text">Text</span>
     </button>
-    <button id="selector-generator" title="__MSG_selectorGenerator__">
+    <button id="selector-generator" data-i18n-title="selectorGenerator">
       <span class="icon">🧬</span>
-      <span class="label">__MSG_selectors__</span>
+      <span class="label" data-i18n="selectors">Selectors</span>
     </button>
   </div>
   <script src="popup.js"></script>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,4 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
+  if (chrome?.i18n) {
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+      el.textContent = chrome.i18n.getMessage(el.dataset.i18n) || el.textContent;
+    });
+    document.querySelectorAll('[data-i18n-title]').forEach(el => {
+      el.title = chrome.i18n.getMessage(el.dataset.i18nTitle) || el.title;
+    });
+  }
   document.querySelectorAll('button').forEach(btn => {
     btn.addEventListener('click', () => {
       chrome.runtime.sendMessage({type: 'ACTIVATE_TOOL', tool: btn.id});


### PR DESCRIPTION
## Summary
- internationalize popup via JS data attributes
- add hover states and tooltips to modal buttons
- support dark mode and draggable/resizable modal
- show small toast messages for actions

## Testing
- `npm test`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_b_6866f23d47508331b34594115a966649