### PR TITLE
Fix popup storage and picker injection

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,11 +1,17 @@
 // background.js
 chrome.runtime.onMessage.addListener(request => {
   if (request.type === 'ACTIVATE_TOOL') {
-    chrome.tabs.query({active: true, currentWindow: true}, tabs => {
-      if (tabs[0]) {
-        chrome.tabs.sendMessage(tabs[0].id, {
-          type: 'ACTIVATE_TOOL_ON_PAGE',
-          tool: request.tool
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      const tab = tabs[0];
+      if (tab) {
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ['content/content.js']
+        }).finally(() => {
+          chrome.tabs.sendMessage(tab.id, {
+            type: 'ACTIVATE_TOOL_ON_PAGE',
+            tool: request.tool
+          });
         });
       }
     });
@@ -13,11 +19,18 @@ chrome.runtime.onMessage.addListener(request => {
 });
 
 chrome.commands.onCommand.addListener(command => {
-  chrome.tabs.query({active: true, currentWindow: true}, tabs => {
-    if (tabs[0]) {
-      chrome.tabs.sendMessage(tabs[0].id, {
-        type: 'ACTIVATE_TOOL_ON_PAGE',
-        tool: command
+  const tool = command.replace(/^activate-/, '');
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    const tab = tabs[0];
+    if (tab) {
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ['content/content.js']
+      }).finally(() => {
+        chrome.tabs.sendMessage(tab.id, {
+          type: 'ACTIVATE_TOOL_ON_PAGE',
+          tool
+        });
       });
     }
   });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "scripting",
     "clipboardWrite",
-    "contextMenus"
+    "contextMenus",
+    "storage"
   ],
   "background": {
     "service_worker": "background.js"
@@ -25,6 +26,9 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "content_scripts": [
     {
       "matches": [
@@ -51,29 +55,29 @@
   ],
   "default_locale": "en",
   "commands": {
-    "color-picker": {
+    "activate-color-picker": {
       "suggested_key": {
-        "default": "Alt+Shift+C"
+        "default": "Ctrl+Shift+C"
       },
-      "description": "Activate color picker"
+      "description": "Activate Color Picker"
     },
-    "element-picker": {
+    "activate-element-picker": {
       "suggested_key": {
-        "default": "Alt+Shift+E"
+        "default": "Ctrl+Shift+E"
       },
-      "description": "Activate element picker"
+      "description": "Activate Element Picker"
     },
-    "link-picker": {
+    "activate-link-picker": {
       "suggested_key": {
-        "default": "Alt+Shift+L"
+        "default": "Ctrl+Shift+L"
       },
-      "description": "Activate link picker"
+      "description": "Activate Link Picker"
     },
-    "selector-generator": {
+    "activate-selector-generator": {
       "suggested_key": {
-        "default": "Alt+Shift+S"
+        "default": "Ctrl+Shift+S"
       },
-      "description": "Activate selector generator"
+      "description": "Activate Selector Generator"
     }
   }
 }

--- a/extension/modules/helpers.js
+++ b/extension/modules/helpers.js
@@ -1,17 +1,18 @@
 // Helper utilities for Pickachu
 let langMap = {};
 if (typeof chrome !== 'undefined') {
-  chrome.storage.sync.get('language', ({language}) => {
-    if (language) {
-      fetch(chrome.runtime.getURL(`_locales/${language}/messages.json`))
-        .then(r => r.json())
-        .then(m => { langMap = m; });
-    }
+  chrome.storage.local.get('language', ({ language }) => {
+    const lang = language || 'en';
+    fetch(chrome.runtime.getURL(`_locales/${lang}/messages.json`))
+      .then(r => r.json())
+      .then(m => { langMap = m; });
   });
 }
 let userTheme = 'system';
 if (typeof chrome !== 'undefined') {
-  chrome.storage.sync.get('theme', ({theme}) => { if (theme) userTheme = theme; });
+  chrome.storage.local.get('theme', ({ theme }) => {
+    if (theme) userTheme = theme;
+  });
   chrome.storage.onChanged.addListener(ch => {
     if (ch.theme) userTheme = ch.theme.newValue;
   });

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -24,31 +24,31 @@
     </div>
   </header>
   <div class="grid">
-    <button id="color-picker" data-i18n-title="colorPicker">
+    <button id="color-picker" title="Color Picker (Ctrl+Shift+C)" data-i18n-title="colorPicker">
       <span class="icon">🎨</span>
       <span class="label" data-i18n="color">Color</span>
     </button>
-    <button id="element-picker" data-i18n-title="elementPicker">
+    <button id="element-picker" title="Element Picker (Ctrl+Shift+E)" data-i18n-title="elementPicker">
       <span class="icon">🧱</span>
       <span class="label" data-i18n="element">Element</span>
     </button>
-    <button id="link-picker" data-i18n-title="linkPicker">
+    <button id="link-picker" title="Link Picker (Ctrl+Shift+L)" data-i18n-title="linkPicker">
       <span class="icon">🔗</span>
       <span class="label" data-i18n="link">Link</span>
     </button>
-    <button id="font-picker" data-i18n-title="fontPicker">
+    <button id="font-picker" title="Font Picker" data-i18n-title="fontPicker">
       <span class="icon">🔤</span>
       <span class="label" data-i18n="font">Font</span>
     </button>
-    <button id="image-picker" data-i18n-title="imagePicker">
+    <button id="image-picker" title="Image Picker" data-i18n-title="imagePicker">
       <span class="icon">🖼️</span>
       <span class="label" data-i18n="image">Image</span>
     </button>
-    <button id="text-picker" data-i18n-title="textPicker">
+    <button id="text-picker" title="Text Picker" data-i18n-title="textPicker">
       <span class="icon">🧾</span>
       <span class="label" data-i18n="text">Text</span>
     </button>
-    <button id="selector-generator" data-i18n-title="selectorGenerator">
+    <button id="selector-generator" title="Selector Generator (Ctrl+Shift+S)" data-i18n-title="selectorGenerator">
       <span class="icon">🧬</span>
       <span class="label" data-i18n="selectors">Selectors</span>
     </button>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -19,9 +19,9 @@ function applyTheme(theme){
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const stored = await chrome.storage.sync.get(['language','theme']);
-  const lang = stored.language || 'en';
-  const theme = stored.theme || 'system';
+  const stored = await chrome.storage.local.get(['language','theme']);
+  const lang = stored?.language || 'en';
+  const theme = stored?.theme || 'system';
   const map = await loadLang(lang);
   applyLang(map);
   document.getElementById('lang-select').value = lang;
@@ -29,13 +29,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   applyTheme(theme);
   document.getElementById('lang-select').addEventListener('change', async e => {
     const newLang = e.target.value;
-    chrome.storage.sync.set({language:newLang});
+    chrome.storage.local.set({language:newLang});
     const m = await loadLang(newLang);
     applyLang(m);
   });
   document.getElementById('theme-select').addEventListener('change', e => {
     const t = e.target.value;
-    chrome.storage.sync.set({theme:t});
+    chrome.storage.local.set({theme:t});
     applyTheme(t);
   });
   document.querySelectorAll('.grid button').forEach(btn => {


### PR DESCRIPTION
## Summary
- add `storage` permission and host permissions
- switch popup and helpers to use chrome.storage.local with fallbacks
- map new keyboard commands to picker IDs
- inject content script before sending messages
- show keyboard hints on picker buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866fcf0b3d48331a2ff5af545db26c6