### PR TITLE
Improve popup theme support and modal styling

### DIFF
--- a/extension/content/content.css
+++ b/extension/content/content.css
@@ -19,6 +19,9 @@
 .light-theme {
   --pickachu-bg: #ffffff;
   --pickachu-text: #333;
+  --pickachu-button-bg: #f0f0f0;
+  --pickachu-button-border: #ccc;
+  --pickachu-hover: #e0e0e0;
 }
 .dark-theme {
   --pickachu-bg: #2b2b2b;
@@ -75,9 +78,12 @@
 #pickachu-modal-content {
   background: var(--pickachu-bg, #fff);
   padding: 20px;
+  border: 1px solid var(--pickachu-button-border, #ccc);
   border-radius: 8px;
   max-width: 80%;
   max-height: 80vh;
+  min-width: 260px;
+  min-height: 160px;
   overflow-y: auto;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   position: absolute;
@@ -110,7 +116,7 @@
 }
 #pickachu-modal-buttons button.copy {
   background: #448aff;
-  color: #fff;
+  color: var(--pickachu-bg, #fff);
   border-color: #448aff;
 }
 
@@ -119,7 +125,7 @@
 }
 
 #pickachu-history .history-item {
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--pickachu-button-border, #ddd);
   padding: 4px 0;
   display: flex;
   align-items: flex-start;
@@ -141,8 +147,8 @@
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(0,0,0,0.8);
-  color: #fff;
+  background: var(--pickachu-button-bg, rgba(0,0,0,0.8));
+  color: var(--pickachu-text, #fff);
   padding: 6px 10px;
   border-radius: 4px;
   z-index: 2147483647;

--- a/extension/modules/helpers.js
+++ b/extension/modules/helpers.js
@@ -159,6 +159,8 @@ export async function showModal(title, content, icon = '', type = '') {
   overlay.id = 'pickachu-modal-overlay';
   const modal = document.createElement('div');
   modal.id = 'pickachu-modal-content';
+  applyTheme(overlay);
+  applyTheme(modal);
   const h3 = document.createElement('h3');
   h3.textContent = `${icon} ${title}`;
   const ta = document.createElement('textarea');

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -4,14 +4,22 @@
   --bg: #f4f4f9;
   --button-bg: #fff;
   --button-border: #ccc;
+  --button-hover: #e9e9ed;
+  --select-bg: #fff;
+  --select-text: #333;
   --text: #333;
+  --modal-border: #ccc;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #2b2b2b;
     --button-bg: #3c3c3c;
     --button-border: #555;
+    --button-hover: #444;
+    --select-bg: #3c3c3c;
+    --select-text: #f5f5f5;
     --text: #f5f5f5;
+    --modal-border: #555;
   }
 }
 
@@ -24,12 +32,20 @@ body {
 }
 .light {
   --bg: #ffffff;
+  --button-bg: #fff;
+  --button-hover: #e9e9ed;
+  --button-border: #ccc;
+  --select-bg: #fff;
+  --select-text: #333;
   --text: #333;
 }
 .dark {
   --bg: #2b2b2b;
   --button-bg: #3c3c3c;
   --button-border: #555;
+  --button-hover: #444;
+  --select-bg: #3c3c3c;
+  --select-text: #f5f5f5;
   --text: #f5f5f5;
 }
 
@@ -40,14 +56,25 @@ body {
   gap: 5px;
 }
 
+.options select {
+  background: var(--select-bg);
+  color: var(--select-text);
+  border: 1px solid var(--button-border);
+  border-radius: 6px;
+  padding: 2px 4px;
+}
+
 .header {
   text-align: center;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--button-border);
   padding-bottom: 10px;
   margin-bottom: 15px;
-  background: linear-gradient(135deg, var(--primary), #00e5ff);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+}
+
+.header h1,
+.header p {
+  margin: 0;
+  color: var(--text);
 }
 
 .grid {
@@ -68,6 +95,7 @@ button {
   align-items: center;
   justify-content: center;
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  color: var(--text);
 }
 
 button .icon {
@@ -80,7 +108,7 @@ button .label {
 }
 
 button:hover {
-  background-color: #e9e9ed;
+  background-color: var(--button-hover);
   transform: translateY(-2px);
   box-shadow: 0 3px 6px rgba(0,0,0,0.15);
 }
@@ -90,4 +118,5 @@ button:hover {
   text-align: center;
   font-size: 12px;
   color: var(--text);
+  font-weight: bold;
 }

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -18,38 +18,48 @@ function applyTheme(theme){
   if(theme==='dark') document.body.classList.add('dark');
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-  const stored = await chrome.storage.local.get(['language','theme']);
-  const lang = stored?.language || 'en';
-  const theme = stored?.theme || 'system';
-  const map = await loadLang(lang);
-  applyLang(map);
-  document.getElementById('lang-select').value = lang;
-  document.getElementById('theme-select').value = theme;
-  applyTheme(theme);
-  document.getElementById('lang-select').addEventListener('change', async e => {
-    const newLang = e.target.value;
-    chrome.storage.local.set({language:newLang});
-    const m = await loadLang(newLang);
-    applyLang(m);
-  });
-  document.getElementById('theme-select').addEventListener('change', e => {
-    const t = e.target.value;
-    chrome.storage.local.set({theme:t});
-    applyTheme(t);
-  });
+document.addEventListener('DOMContentLoaded', () => {
+  const langSelect = document.getElementById('lang-select');
+  const themeSelect = document.getElementById('theme-select');
+
   document.querySelectorAll('.grid button').forEach(btn => {
     btn.addEventListener('click', () => {
-      chrome.runtime.sendMessage({type: 'ACTIVATE_TOOL', tool: btn.id});
+      chrome.runtime.sendMessage({ type: 'ACTIVATE_TOOL', tool: btn.id });
       window.close();
     });
   });
-  document.querySelectorAll('.grid button').forEach(btn => {
-    const hint = btn.dataset.shortcut;
-    if (hint) {
-      const titleId = btn.dataset.i18nTitle;
-      const base = map[titleId]?.message || btn.title;
-      btn.title = `${base} (${hint})`;
-    }
-  });
+
+  (async () => {
+    const stored = await chrome.storage.local.get(['language', 'theme']);
+    const lang = stored?.language || 'en';
+    const theme = stored?.theme || 'system';
+    const map = await loadLang(lang);
+
+    applyLang(map);
+    langSelect.value = lang;
+    themeSelect.value = theme;
+    applyTheme(theme);
+
+    langSelect.addEventListener('change', async e => {
+      const newLang = e.target.value;
+      chrome.storage.local.set({ language: newLang });
+      const m = await loadLang(newLang);
+      applyLang(m);
+    });
+
+    themeSelect.addEventListener('change', e => {
+      const t = e.target.value;
+      chrome.storage.local.set({ theme: t });
+      applyTheme(t);
+    });
+
+    document.querySelectorAll('.grid button').forEach(btn => {
+      const hint = btn.dataset.shortcut;
+      if (hint) {
+        const titleId = btn.dataset.i18nTitle;
+        const base = map[titleId]?.message || btn.title;
+        btn.title = `${base} (${hint})`;
+      }
+    });
+  })();
 });


### PR DESCRIPTION
## Summary
- make popup event listeners bind immediately
- apply theme variables across components
- style dropdowns for contrast in dark and light modes
- tweak modal styling for consistent themes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686705e8e6908331af1998b2444ccabc