### PR TITLE
Add macOS shortcut mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The popup provides buttons to activate each tool. Data from the page is copied t
 clipboard and displayed in a short notification.
 
 ## Keyboard Shortcuts
-Pickachu defines a single shortcut using the Chrome `commands` API. Press `Ctrl+Shift+P` to open the popup from any page.
+Pickachu defines a single shortcut using the Chrome `commands` API. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) to open the popup from any page.
 
 | Action | Shortcut |
 | ------ | -------- |
-| Open popup | `Ctrl+Shift+P` |
+| Open popup | `Ctrl+Shift+P` / `Cmd+Shift+P` (macOS) |
 
 ## Repository Structure
 ```

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -78,7 +78,7 @@
     "message": "Text"
   },
   "openShortcut": {
-    "message": "Press Ctrl+Shift+P to open Pickachu"
+    "message": "Press Ctrl+Shift+P (Cmd+Shift+P on Mac) to open Pickachu"
   },
   "createdBy": {
     "message": "Created by Adem İsler"

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -78,7 +78,7 @@
     "message": "Texte"
   },
   "openShortcut": {
-    "message": "Appuyez sur Ctrl+Maj+P pour ouvrir Pickachu"
+    "message": "Appuyez sur Ctrl+Maj+P (Cmd+Maj+P sur Mac) pour ouvrir Pickachu"
   },
   "createdBy": {
     "message": "Créé par Adem İsler"

--- a/extension/_locales/tr/messages.json
+++ b/extension/_locales/tr/messages.json
@@ -78,7 +78,7 @@
     "message": "Metin"
   },
   "openShortcut": {
-    "message": "Pickachu'yu açmak için Ctrl+Shift+P tuşlayın"
+    "message": "Pickachu'yu açmak için Ctrl+Shift+P (Mac'te Cmd+Shift+P) tuşlayın"
   },
   "createdBy": {
     "message": "Geliştirici: Adem İsler"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -57,7 +57,8 @@
   "commands": {
     "open-popup": {
       "suggested_key": {
-        "default": "Ctrl+Shift+P"
+        "default": "Ctrl+Shift+P",
+        "mac": "Command+Shift+P"
       },
       "description": "Open Pickachu"
     }

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -50,7 +50,7 @@
 </button>
   </div>
   <div class="shortcuts" data-i18n="openShortcut">
-    Press Ctrl+Shift+P to open Pickachu
+    Press Ctrl+Shift+P (Cmd+Shift+P on Mac) to open Pickachu
   </div>
   <div class="footer">
     <a href="https://ademisler.com/" target="_blank" class="icon-btn" data-i18n="createdBy">Created by Adem İsler</a>


### PR DESCRIPTION
## Summary
- mention Cmd+Shift+P across README and popup
- update `openShortcut` translations
- specify mac key in the extension manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68671044bb7c8331a271c14151848504