### PR TITLE
Add shortcuts link in popup

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -78,7 +78,7 @@
     "message": "Text"
   },
   "openShortcut": {
-    "message": "Press Ctrl+Shift+P (Cmd+Shift+P on Mac) to open Pickachu"
+    "message": "Ctrl+Shift+P"
   },
   "createdBy": {
     "message": "Created by Adem İsler"

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -78,7 +78,7 @@
     "message": "Texte"
   },
   "openShortcut": {
-    "message": "Appuyez sur Ctrl+Maj+P (Cmd+Maj+P sur Mac) pour ouvrir Pickachu"
+    "message": "Ctrl+Shift+P"
   },
   "createdBy": {
     "message": "Créé par Adem İsler"

--- a/extension/_locales/tr/messages.json
+++ b/extension/_locales/tr/messages.json
@@ -78,7 +78,7 @@
     "message": "Metin"
   },
   "openShortcut": {
-    "message": "Pickachu'yu açmak için Ctrl+Shift+P (Mac'te Cmd+Shift+P) tuşlayın"
+    "message": "Ctrl+Shift+P"
   },
   "createdBy": {
     "message": "Geliştirici: Adem İsler"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -46,7 +46,9 @@
     {
       "resources": [
         "modules/*.js",
-        "content/*.css"
+        "content/*.css",
+        "shortcuts.html",
+        "shortcuts.md"
       ],
       "matches": [
         "<all_urls>"

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -136,6 +136,13 @@ button:hover {
   color: var(--text);
   font-weight: bold;
 }
+.shortcuts a {
+  color: var(--text);
+  text-decoration: none;
+}
+.shortcuts a:hover {
+  text-decoration: underline;
+}
 
 .footer {
   margin-top: 8px;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -49,8 +49,8 @@
   <span class="label" data-i18n="text">Text</span>
 </button>
   </div>
-  <div class="shortcuts" data-i18n="openShortcut">
-    Press Ctrl+Shift+P (Cmd+Shift+P on Mac) to open Pickachu
+  <div class="shortcuts">
+    <a href="#" id="shortcut-link" data-i18n="openShortcut">Ctrl+Shift+P</a>
   </div>
   <div class="footer">
     <a href="https://ademisler.com/" target="_blank" class="icon-btn" data-i18n="createdBy">Created by Adem İsler</a>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -29,6 +29,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  const shortcutLink = document.getElementById('shortcut-link');
+  if (shortcutLink) {
+    shortcutLink.addEventListener('click', e => {
+      e.preventDefault();
+      chrome.tabs.create({ url: chrome.runtime.getURL('shortcuts.html') });
+    });
+  }
+
   (async () => {
     const stored = await chrome.storage.local.get(['language', 'theme']);
     const lang = stored?.language || 'en';

--- a/extension/shortcuts.html
+++ b/extension/shortcuts.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pickachu Shortcuts</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; line-height: 1.6; }
+    pre { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <pre id="content"></pre>
+  <script>
+    fetch(chrome.runtime.getURL('shortcuts.md'))
+      .then(res => res.text())
+      .then(text => {
+        document.getElementById('content').textContent = text;
+      });
+  </script>
+</body>
+</html>

--- a/extension/shortcuts.md
+++ b/extension/shortcuts.md
@@ -1,0 +1,8 @@
+# Keyboard Shortcuts
+
+Pickachu defines a single shortcut using the Chrome `commands` API.
+
+| Action | Shortcut |
+| ------ | -------- |
+| Open popup | `Ctrl+Shift+P` / `Cmd+Shift+P` (macOS) |
+


### PR DESCRIPTION
## Summary
- shrink the popup shortcut message to a link
- open a new markdown page showing keyboard shortcuts
- update styles and locale messages
- expose markdown files via manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686714ae74f88331a9849859c6ec630f