### PR TITLE
Display both popup shortcuts

### DIFF
--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -44,16 +44,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (shortcutsEl) {
       const base = map.openShortcut?.message || 'Ctrl+Shift+P';
-      const combo = navigator.platform.includes('Mac') ?
-        base.replace('Ctrl', 'Cmd') : base;
+      const combos = [base, base.replace('Ctrl', 'Cmd')];
       shortcutsEl.innerHTML = '';
-      combo.split('+').forEach((k, i, arr) => {
-        const span = document.createElement('span');
-        span.className = 'key';
-        span.textContent = k;
-        shortcutsEl.appendChild(span);
-        if (i < arr.length - 1) {
-          const sep = document.createTextNode('+');
+
+      combos.forEach((combo, idx) => {
+        combo.split('+').forEach((k, i, arr) => {
+          const span = document.createElement('span');
+          span.className = 'key';
+          span.textContent = k;
+          shortcutsEl.appendChild(span);
+          if (i < arr.length - 1) {
+            const sep = document.createTextNode('+');
+            shortcutsEl.appendChild(sep);
+          }
+        });
+
+        if (idx === 0) {
+          const sep = document.createTextNode(' / ');
           shortcutsEl.appendChild(sep);
         }
       });


### PR DESCRIPTION
## Summary
- show both `Ctrl+Shift+P` and `Cmd+Shift+P` shortcut keys in the popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68671f7121a883319df5582deb3bc28c