### PR TITLE
Reduce popup shortcut size

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -130,18 +130,18 @@ button:hover {
 }
 
 .shortcuts {
-  margin-top: 10px;
+  margin-top: 6px;
   text-align: center;
-  font-size: 12px;
+  font-size: 10px;
   color: var(--text);
-  font-weight: bold;
+  font-weight: normal;
 }
 .shortcuts .key {
   display: inline-block;
   background: var(--button-bg);
   border: 1px solid var(--button-border);
   border-radius: 4px;
-  padding: 2px 4px;
+  padding: 1px 3px;
   margin: 0 1px;
 }
 


### PR DESCRIPTION
## Summary
- keep the keyboard shortcut hint in the popup but make it smaller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686720d3976c8331bf98581ac08ae4dd