### PR TITLE
Change keyboard shortcut to Ctrl+Shift+9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The popup provides buttons to activate each tool. Data from the page is copied t
 clipboard and displayed in a short notification.
 
 ## Keyboard Shortcuts
-Pickachu defines a single shortcut using the Chrome `commands` API. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) to open the popup from any page.
+Pickachu defines a single shortcut using the Chrome `commands` API. Press `Ctrl+Shift+9` (or `Cmd+Shift+9` on macOS) to open the popup from any page.
 
 | Action | Shortcut |
 | ------ | -------- |
-| Open popup | `Ctrl+Shift+P` / `Cmd+Shift+P` (macOS) |
+| Open popup | `Ctrl+Shift+9` / `Cmd+Shift+9` (macOS) |
 
 ## Repository Structure
 ```

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -81,7 +81,7 @@
     "message": "Text"
   },
   "openShortcut": {
-    "message": "Ctrl+Shift+P"
+    "message": "Ctrl+Shift+9"
   },
   "createdBy": {
     "message": "Created by Adem İsler"

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -81,7 +81,7 @@
     "message": "Texte"
   },
   "openShortcut": {
-    "message": "Ctrl+Shift+P"
+    "message": "Ctrl+Shift+9"
   },
   "createdBy": {
     "message": "Créé par Adem İsler"

--- a/extension/_locales/tr/messages.json
+++ b/extension/_locales/tr/messages.json
@@ -81,7 +81,7 @@
     "message": "Metin"
   },
   "openShortcut": {
-    "message": "Ctrl+Shift+P"
+    "message": "Ctrl+Shift+9"
   },
   "createdBy": {
     "message": "Geliştirici: Adem İsler"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -57,8 +57,8 @@
   "commands": {
     "open-popup": {
       "suggested_key": {
-        "default": "Ctrl+Shift+P",
-        "mac": "Command+Shift+P"
+        "default": "Ctrl+Shift+9",
+        "mac": "Command+Shift+9"
       },
       "description": "Open Pickachu"
     }

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     applyTheme(theme);
 
     if (shortcutsEl) {
-      const base = map.openShortcut?.message || 'Ctrl+Shift+P';
+      const base = map.openShortcut?.message || 'Ctrl+Shift+9';
       const combos = [base, base.replace('Ctrl', 'Cmd')];
       shortcutsEl.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- use a more uncommon shortcut for opening the popup
- update locales, popup and documentation to use the new key combo

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867be71525c8331bdcd00972618b471