### PR TITLE
Simplify popup title

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Pickachu – Web Picker Tool"
+    "message": "Pickachu"
   },
   "extensionDescription": {
     "message": "A lightweight picker toolbox to collect colors, elements, links, fonts, images, and text from any webpage."

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Pickachu – Outil de Sélection Web"
+    "message": "Pickachu"
   },
   "extensionDescription": {
     "message": "Une boîte à outils légère pour collecter les couleurs, éléments, liens, polices, images et textes de n'importe quelle page web."

--- a/extension/_locales/tr/messages.json
+++ b/extension/_locales/tr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Pickachu – Web Seçme Aracı"
+    "message": "Pickachu"
   },
   "extensionDescription": {
     "message": "Herhangi bir web sayfasından renk, öğe, bağlantı, yazı tipi, resim ve metin toplamak için hafif bir seçme araç kutusu."

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title data-i18n="extensionName">Pickachu – Web Picker Tool</title>
+  <title data-i18n="extensionName">Pickachu</title>
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
   <header class="header">
-    <h1>⚡ <span data-i18n="extensionName">Pickachu – Web Picker Tool</span></h1>
+    <h1>⚡<span data-i18n="extensionName">Pickachu</span></h1>
     <p data-i18n="popupSubtitle">Quick web picker tools</p>
     <div class="options">
       <select id="lang-select">


### PR DESCRIPTION
## Summary
- shorten the popup title
- update extension name across locales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867c409167083318271e45b5e2efdbc