### PR TITLE
Update extension name translations

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Pickachu"
+    "message": "Pickachu – Web Picker Tool"
   },
   "extensionDescription": {
     "message": "A lightweight picker toolbox to collect colors, elements, links, fonts, images, and text from any webpage."

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Pickachu"
+    "message": "Pickachu – Outil de sélection Web"
   },
   "extensionDescription": {
     "message": "Une boîte à outils légère pour collecter les couleurs, éléments, liens, polices, images et textes de n'importe quelle page web."

--- a/extension/_locales/tr/messages.json
+++ b/extension/_locales/tr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Pickachu"
+    "message": "Pickachu – Web Seçme Aracı"
   },
   "extensionDescription": {
     "message": "Herhangi bir web sayfasından renk, öğe, bağlantı, yazı tipi, resim ve metin toplamak için hafif bir seçme araç kutusu."

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,6 +15,7 @@
   },
   "action": {
     "default_popup": "popup/popup.html",
+    "default_title": "__MSG_extensionName__",
     "default_icon": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png",

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header class="header">
-    <h1>⚡<span data-i18n="extensionName">Pickachu</span></h1>
+    <h1>⚡<span>Pickachu</span></h1>
     <p data-i18n="popupSubtitle">Quick web picker tools</p>
     <div class="options">
       <select id="lang-select">


### PR DESCRIPTION
## Summary
- localize the extension name as "Pickachu – Web Picker Tool" in English
- add French and Turkish translations for "Web Picker Tool"
- show only "Pickachu" inside the popup
- expose the localized extension name as the action tooltip in manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867fdd457c48331acb2b7972d11532a